### PR TITLE
nix: forward --derivation to path-info for unbuilt installables

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,14 +48,13 @@ async fn main() -> Result<()> {
     }
 
     println!("Loading store paths...");
-    let graph = nix::query_path_info(
-        &paths,
-        true,
-        config.store.as_deref(),
-        &config.nix_options,
-        config.file.as_deref(),
-    )
-    .await?;
+    let opts = nix::QueryOptions {
+        store: config.store,
+        nix_options: config.nix_options,
+        file: config.file,
+        derivation: config.derivation,
+    };
+    let graph = nix::query_path_info(&paths, true, &opts).await?;
 
     println!("Calculating sizes...");
     let stats = path_stats::calculate_stats(&graph);

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -18,33 +18,43 @@ struct NixPathInfo {
     closure_size: Option<u64>,
 }
 
-/// Resolve flake references and other inputs to store paths
-async fn resolve_paths(
-    paths: &[String],
-    store: Option<&str>,
-    nix_options: &[(String, String)],
-    file: Option<&str>,
-) -> Result<Vec<String>> {
-    let mut cmd = Command::new("nix");
-    cmd.arg("--extra-experimental-features")
-        .arg("nix-command flakes");
+#[derive(Debug, Default, Clone)]
+pub struct QueryOptions {
+    pub store: Option<String>,
+    pub nix_options: Vec<(String, String)>,
+    pub file: Option<String>,
+    pub derivation: bool,
+}
 
-    // Add nix options
-    for (name, value) in nix_options {
+/// Must be called after the `path-info` subcommand: `--file`/`--derivation`
+/// are subcommand flags and are rejected in global position.
+fn apply_common_args(cmd: &mut Command, opts: &QueryOptions) {
+    for (name, value) in &opts.nix_options {
         cmd.arg("--option").arg(name).arg(value);
     }
 
-    if let Some(store_url) = store {
+    if let Some(store_url) = &opts.store {
         cmd.arg("--store").arg(store_url);
     }
 
-    if let Some(file_path) = file {
+    if let Some(file_path) = &opts.file {
         cmd.arg("--file").arg(file_path);
     }
 
-    cmd.arg("path-info")
-        .arg("--json")
-        .args(paths)
+    if opts.derivation {
+        cmd.arg("--derivation");
+    }
+}
+
+/// Resolve flake references and other inputs to store paths
+async fn resolve_paths(paths: &[String], opts: &QueryOptions) -> Result<Vec<String>> {
+    let mut cmd = Command::new("nix");
+    cmd.arg("--extra-experimental-features")
+        .arg("nix-command flakes")
+        .arg("path-info")
+        .arg("--json");
+    apply_common_args(&mut cmd, opts);
+    cmd.args(paths)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
@@ -66,34 +76,24 @@ async fn resolve_paths(
 pub async fn query_path_info(
     paths: &[String],
     recursive: bool,
-    store: Option<&str>,
-    nix_options: &[(String, String)],
-    file: Option<&str>,
+    opts: &QueryOptions,
 ) -> Result<StorePathGraph> {
     // First resolve any flake references to store paths
-    let resolved_paths = resolve_paths(paths, store, nix_options, file).await?;
+    let resolved_paths = resolve_paths(paths, opts).await?;
 
     let mut cmd = Command::new("nix");
     cmd.arg("--extra-experimental-features")
-        .arg("nix-command flakes");
-
-    // Add nix options
-    for (name, value) in nix_options {
-        cmd.arg("--option").arg(name).arg(value);
-    }
-
-    if let Some(store_url) = store {
-        cmd.arg("--store").arg(store_url);
-    }
-
-    if let Some(file_path) = file {
-        cmd.arg("--file").arg(file_path);
-    }
-
-    cmd.arg("path-info")
+        .arg("nix-command flakes")
+        .arg("path-info")
         .arg("--json")
-        .arg("--closure-size")
-        .args(&resolved_paths)
+        .arg("--closure-size");
+    // resolved_paths are store paths; --file would misinterpret them as attrs.
+    let store_opts = QueryOptions {
+        file: None,
+        ..opts.clone()
+    };
+    apply_common_args(&mut cmd, &store_opts);
+    cmd.args(&resolved_paths)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::io::Write;
 use std::process::Command;
 
 #[tokio::test]
@@ -27,7 +28,7 @@ async fn test_parse_hello_derivation() -> Result<()> {
     assert!(name.contains("hello"));
 
     let paths = vec![drv_path];
-    let graph = nix_tree::nix::query_path_info(&paths, true, None).await?;
+    let graph = nix_tree::nix::query_path_info(&paths, true, &Default::default()).await?;
 
     assert!(!graph.paths.is_empty());
 
@@ -41,6 +42,41 @@ async fn test_parse_hello_derivation() -> Result<()> {
 
     let hello_stats = stats.get(&paths[0]).expect("Should have stats for hello");
     assert!(hello_stats.closure_size > 0);
+
+    Ok(())
+}
+
+/// https://github.com/Mic92/nix-tree-rs/issues/23
+#[tokio::test]
+async fn test_unbuilt_derivation_flag() -> Result<()> {
+    let mut expr = tempfile::NamedTempFile::with_suffix(".nix")?;
+    // Unique salt keeps the output path unbuilt across test runs.
+    let salt: u128 = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_nanos();
+    write!(
+        expr,
+        r#"derivation {{
+  name = "nix-tree-unbuilt-test";
+  builder = "/bin/sh";
+  args = [ "-c" "echo unreachable > $out" ];
+  system = builtins.currentSystem;
+  salt = "{salt}";
+}}"#
+    )?;
+    expr.flush()?;
+
+    let opts = nix_tree::nix::QueryOptions {
+        file: Some(expr.path().to_string_lossy().into_owned()),
+        derivation: true,
+        ..Default::default()
+    };
+
+    let graph = nix_tree::nix::query_path_info(&[String::new()], true, &opts).await?;
+
+    assert_eq!(graph.roots.len(), 1);
+    let root = &graph.roots[0];
+    assert!(root.ends_with(".drv"), "expected .drv root, got {root}");
 
     Ok(())
 }

--- a/tests/ui_test.rs
+++ b/tests/ui_test.rs
@@ -16,7 +16,7 @@ async fn test_initial_dependencies_loading() {
         }
     }
 
-    let graph = nix_tree::nix::query_path_info(&paths, true, None)
+    let graph = nix_tree::nix::query_path_info(&paths, true, &Default::default())
         .await
         .unwrap();
 


### PR DESCRIPTION

The --derivation flag was parsed but never reached the underlying nix
invocations, so querying an installable whose outputs had not been built
failed with "cannot operate on output of the unbuilt derivation". Bundle
the per-query flags into a QueryOptions struct and forward --derivation
(and the other flags) after the path-info subcommand, where nix actually
accepts them. Drop --file from the second call since it now receives
resolved store paths and would otherwise reinterpret them as attributes.

The integration and ui tests had bit-rotted against an older
query_path_info signature; update them and add a regression test that
queries a guaranteed-unbuilt derivation via --file/--derivation.

Fixes #23


