### PR TITLE
nix: handle null path-info entries and dedupe command setup

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,7 @@ pub fn parse_args() -> Result<Config> {
                 config.file = Some(arg.strip_prefix("--file=").unwrap().to_string());
             }
             arg if arg.starts_with('-') => {
-                bail!("Unknown option: {}", arg);
+                bail!("Unknown option: {arg}");
             }
             _ => {
                 config.paths.push(args[i].clone());

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -26,51 +26,59 @@ pub struct QueryOptions {
     pub derivation: bool,
 }
 
-/// Must be called after the `path-info` subcommand: `--file`/`--derivation`
-/// are subcommand flags and are rejected in global position.
-fn apply_common_args(cmd: &mut Command, opts: &QueryOptions) {
-    for (name, value) in &opts.nix_options {
-        cmd.arg("--option").arg(name).arg(value);
-    }
-
-    if let Some(store_url) = &opts.store {
-        cmd.arg("--store").arg(store_url);
-    }
-
-    if let Some(file_path) = &opts.file {
-        cmd.arg("--file").arg(file_path);
-    }
-
-    if opts.derivation {
-        cmd.arg("--derivation");
-    }
-}
-
-/// Resolve flake references and other inputs to store paths
-async fn resolve_paths(paths: &[String], opts: &QueryOptions) -> Result<Vec<String>> {
+/// `--file`/`--derivation` are subcommand flags, so this builds up to and
+/// including `path-info` before applying them.
+fn path_info_cmd(opts: &QueryOptions) -> Command {
     let mut cmd = Command::new("nix");
     cmd.arg("--extra-experimental-features")
         .arg("nix-command flakes")
         .arg("path-info")
         .arg("--json");
-    apply_common_args(&mut cmd, opts);
-    cmd.args(paths)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
 
-    let output = cmd.output().await.context("Failed to run nix path-info")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("nix path-info failed: {}", stderr);
+    for (name, value) in &opts.nix_options {
+        cmd.arg("--option").arg(name).arg(value);
+    }
+    if let Some(store_url) = &opts.store {
+        cmd.arg("--store").arg(store_url);
+    }
+    if let Some(file_path) = &opts.file {
+        cmd.arg("--file").arg(file_path);
+    }
+    if opts.derivation {
+        cmd.arg("--derivation");
     }
 
-    let json_str = String::from_utf8(output.stdout).context("Invalid UTF-8 in nix output")?;
-    let path_info_map: std::collections::HashMap<String, NixPathInfo> =
-        serde_json::from_str(&json_str).context("Failed to parse nix path-info JSON")?;
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    cmd
+}
 
-    // Return the resolved store paths
-    Ok(path_info_map.keys().cloned().collect())
+async fn run_path_info<T: serde::de::DeserializeOwned>(mut cmd: Command) -> Result<T> {
+    let output = cmd.output().await.context("Failed to run nix path-info")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("nix path-info failed: {stderr}");
+    }
+    serde_json::from_slice(&output.stdout).context("Failed to parse nix path-info JSON")
+}
+
+/// Resolve flake references and other inputs to store paths
+async fn resolve_paths(paths: &[String], opts: &QueryOptions) -> Result<Vec<String>> {
+    let mut cmd = path_info_cmd(opts);
+    cmd.args(paths);
+
+    // For paths not in the store nix emits `"<path>": null` with exit 0, so
+    // the value side must tolerate null instead of forcing NixPathInfo.
+    let map: std::collections::HashMap<String, Option<serde_json::Value>> =
+        run_path_info(cmd).await?;
+
+    let mut resolved = Vec::with_capacity(map.len());
+    for (path, info) in map {
+        if info.is_none() {
+            anyhow::bail!("store path '{path}' is not valid (output not built?); try --derivation");
+        }
+        resolved.push(path);
+    }
+    Ok(resolved)
 }
 
 pub async fn query_path_info(
@@ -81,40 +89,18 @@ pub async fn query_path_info(
     // First resolve any flake references to store paths
     let resolved_paths = resolve_paths(paths, opts).await?;
 
-    let mut cmd = Command::new("nix");
-    cmd.arg("--extra-experimental-features")
-        .arg("nix-command flakes")
-        .arg("path-info")
-        .arg("--json")
-        .arg("--closure-size");
     // resolved_paths are store paths; --file would misinterpret them as attrs.
-    let store_opts = QueryOptions {
+    let mut cmd = path_info_cmd(&QueryOptions {
         file: None,
         ..opts.clone()
-    };
-    apply_common_args(&mut cmd, &store_opts);
-    cmd.args(&resolved_paths)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
+    });
+    cmd.arg("--closure-size");
     if recursive {
         cmd.arg("--recursive");
     }
+    cmd.args(&resolved_paths);
 
-    let output = cmd
-        .output()
-        .await
-        .context("Failed to execute nix path-info")?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("nix path-info failed: {}", stderr);
-    }
-
-    let json_str = String::from_utf8(output.stdout).context("Invalid UTF-8 in nix output")?;
-
-    let path_info_map: std::collections::HashMap<String, NixPathInfo> =
-        serde_json::from_str(&json_str).context("Failed to parse nix path-info JSON")?;
+    let path_info_map: std::collections::HashMap<String, NixPathInfo> = run_path_info(cmd).await?;
 
     let mut graph = StorePathGraph::new();
 

--- a/src/store_path.rs
+++ b/src/store_path.rs
@@ -18,21 +18,21 @@ impl StorePath {
         let path = path.trim();
 
         if !path.starts_with("/nix/store/") {
-            bail!("Invalid store path: {}", path);
+            bail!("Invalid store path: {path}");
         }
 
         let without_prefix = path.strip_prefix("/nix/store/").unwrap();
         let parts: Vec<&str> = without_prefix.splitn(2, '-').collect();
 
         if parts.len() != 2 {
-            bail!("Invalid store path format: {}", path);
+            bail!("Invalid store path format: {path}");
         }
 
         let hash = parts[0].to_string();
         let name = parts[1].to_string();
 
         if hash.len() != 32 {
-            bail!("Invalid store path hash length: {}", hash);
+            bail!("Invalid store path hash length: {hash}");
         }
 
         Ok((hash, name))

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation},
 };
 use std::collections::HashSet;
 
@@ -231,16 +231,19 @@ fn calculate_added_size_for_path(
     context_total_size.saturating_sub(filtered_size)
 }
 
-pub fn render_why_depends(
-    f: &mut Frame,
-    area: Rect,
-    formatted_lines: &[String],
-    max_line_width: usize,
-    selected: usize,
-    vertical_scroll_state: ScrollbarState,
-    horizontal_scroll_state: ScrollbarState,
-    horizontal_scroll: usize,
-) {
+pub fn render_why_depends(f: &mut Frame, area: Rect, modal: &Modal) {
+    let Modal::WhyDepends {
+        paths: _,
+        formatted_lines,
+        max_line_width,
+        selected,
+        vertical_scroll_state,
+        horizontal_scroll_state,
+        horizontal_scroll,
+    } = modal;
+    let (max_line_width, selected, horizontal_scroll) =
+        (*max_line_width, *selected, *horizontal_scroll);
+
     let modal_area = centered_rect(90, 60, area);
 
     // Clear with black background
@@ -298,7 +301,7 @@ pub fn render_why_depends(
             .begin_symbol(Some("↑"))
             .end_symbol(Some("↓"));
 
-        let mut v_state = vertical_scroll_state;
+        let mut v_state = *vertical_scroll_state;
         // Ensure the inner area calculation doesn't go negative
         if inner_area.height > 2 {
             f.render_stateful_widget(
@@ -318,7 +321,7 @@ pub fn render_why_depends(
             .begin_symbol(Some("←"))
             .end_symbol(Some("→"));
 
-        let mut h_state = horizontal_scroll_state;
+        let mut h_state = *horizontal_scroll_state;
         f.render_stateful_widget(
             horizontal_scrollbar,
             inner_area.inner(Margin {
@@ -333,26 +336,7 @@ pub fn render_why_depends(
 pub fn render_modal(f: &mut Frame, app: &App, area: Rect) {
     if let Some(modal) = &app.modal {
         match modal {
-            Modal::WhyDepends {
-                paths: _,
-                formatted_lines,
-                max_line_width,
-                selected,
-                vertical_scroll_state,
-                horizontal_scroll_state,
-                horizontal_scroll,
-            } => {
-                render_why_depends(
-                    f,
-                    area,
-                    formatted_lines,
-                    *max_line_width,
-                    *selected,
-                    *vertical_scroll_state,
-                    *horizontal_scroll_state,
-                    *horizontal_scroll,
-                );
-            }
+            Modal::WhyDepends { .. } => render_why_depends(f, area, modal),
         }
     }
 }


### PR DESCRIPTION

nix path-info returns `{"<path>": null}` with exit 0 when an output is
not in the store, which the resolver tried to deserialise as a full
NixPathInfo and surfaced as an opaque serde error. Accept null values
and turn them into an actionable error pointing at --derivation.

Fold the duplicated command construction and output handling into
path_info_cmd/run_path_info so both call sites stay in sync, and pass
--recursive ahead of the positional paths while at it.
