### PR TITLE
nix: reword not-in-store error to cover GC as well as unbuilt

### DIFF
--- a/benches/scroll.rs
+++ b/benches/scroll.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
     // Put a large list into the current pane to mimic the laggy case
     // (e.g. referrers of glibc, or search results).
     let mut all: Vec<String> = app.graph.paths.iter().map(|p| p.path.clone()).collect();
-    path_stats::sort_paths(&mut all, &app.stats, app.sort_order);
+    path_stats::sort_paths(&mut all, &app.graph, &app.stats, app.sort_order, None);
     eprintln!("  current pane size: {}", all.len());
     app.current_items = all;
     app.current_state.select(Some(0));

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -72,7 +72,9 @@ async fn resolve_paths(paths: &[String], opts: &QueryOptions) -> Result<Vec<Stri
     let mut resolved = Vec::with_capacity(map.len());
     for (path, info) in map {
         if info.is_none() {
-            anyhow::bail!("store path '{path}' is not valid (output not built?); try --derivation");
+            anyhow::bail!(
+                "'{path}' is not in the store (garbage-collected, or pass --derivation for unbuilt outputs)"
+            );
         }
         resolved.push(path);
     }

--- a/src/path_stats.rs
+++ b/src/path_stats.rs
@@ -100,6 +100,20 @@ impl AddedSize {
         }
     }
 
+    /// Added sizes for every `item` relative to `context`, computed in one pass
+    /// so the cached context total is reused across the batch.
+    pub fn for_items(
+        &mut self,
+        graph: &StorePathGraph,
+        items: &[String],
+        context: &[String],
+    ) -> HashMap<String, u64> {
+        items
+            .iter()
+            .map(|p| (p.clone(), self.for_path(graph, p, context)))
+            .collect()
+    }
+
     pub fn for_path(&mut self, graph: &StorePathGraph, path: &str, context: &[String]) -> u64 {
         let roots: Vec<u32> = context
             .iter()
@@ -123,7 +137,6 @@ impl AddedSize {
 #[derive(Debug, Clone)]
 pub struct PathStats {
     pub closure_size: u64,
-    pub added_size: Option<u64>, // None means not yet calculated
     pub immediate_parents: Vec<String>,
 }
 
@@ -143,7 +156,6 @@ pub fn calculate_stats(graph: &StorePathGraph) -> HashMap<String, PathStats> {
             path.path.clone(),
             PathStats {
                 closure_size,
-                added_size: None, // Will be calculated on-demand
                 immediate_parents,
             },
         );
@@ -177,25 +189,36 @@ impl SortOrder {
     }
 }
 
-pub fn sort_paths(paths: &mut [String], stats: &HashMap<String, PathStats>, order: SortOrder) {
-    paths.sort_by(|a, b| {
-        let stat_a = stats.get(a);
-        let stat_b = stats.get(b);
-
-        match order {
-            SortOrder::Alphabetical => a.cmp(b),
-            SortOrder::ClosureSize => {
-                let size_a = stat_a.map(|s| s.closure_size).unwrap_or(0);
-                let size_b = stat_b.map(|s| s.closure_size).unwrap_or(0);
-                size_b.cmp(&size_a)
-            }
-            SortOrder::AddedSize => {
-                let size_a = stat_a.and_then(|s| s.added_size).unwrap_or(0);
-                let size_b = stat_b.and_then(|s| s.added_size).unwrap_or(0);
-                size_b.cmp(&size_a)
-            }
+pub fn sort_paths(
+    paths: &mut [String],
+    graph: &StorePathGraph,
+    stats: &HashMap<String, PathStats>,
+    order: SortOrder,
+    added: Option<&HashMap<String, u64>>,
+) {
+    match order {
+        SortOrder::Alphabetical => {
+            paths.sort_by(|a, b| {
+                let na = graph.get_path(a).map(|p| p.name.as_str()).unwrap_or(a);
+                let nb = graph.get_path(b).map(|p| p.name.as_str()).unwrap_or(b);
+                na.cmp(nb)
+            });
         }
-    });
+        SortOrder::ClosureSize => {
+            paths.sort_by_key(|p| std::cmp::Reverse(stats.get(p).map_or(0, |s| s.closure_size)));
+        }
+        SortOrder::AddedSize => {
+            // Without a context (e.g. referrers pane) added size is undefined;
+            // closure size is the next best stable order.
+            paths.sort_by_key(|p| {
+                std::cmp::Reverse(
+                    added
+                        .and_then(|m| m.get(p).copied())
+                        .unwrap_or_else(|| stats.get(p).map_or(0, |s| s.closure_size)),
+                )
+            });
+        }
+    }
 }
 
 // Trie-like structure for efficient path storage

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -61,6 +61,25 @@ impl App {
             .for_path(&self.graph, path, &context)
     }
 
+    fn sorted(&self, mut items: Vec<String>, context: Option<&[String]>) -> Vec<String> {
+        let added = match (self.sort_order, context) {
+            (SortOrder::AddedSize, Some(ctx)) => Some(self.added_size.borrow_mut().for_items(
+                &self.graph,
+                &items,
+                ctx,
+            )),
+            _ => None,
+        };
+        crate::path_stats::sort_paths(
+            &mut items,
+            &self.graph,
+            &self.stats,
+            self.sort_order,
+            added.as_ref(),
+        );
+        items
+    }
+
     pub fn get_parent_context(&self) -> Vec<String> {
         // Get the parent context from navigation history
         // For added size calculation, we need the specific parent we navigated from
@@ -104,7 +123,9 @@ impl App {
 
         // Start with all roots in the current pane
         app.current_items = app.graph.roots.clone();
-        crate::path_stats::sort_paths(&mut app.current_items, &app.stats, app.sort_order);
+        let roots = app.graph.roots.clone();
+        let items = std::mem::take(&mut app.current_items);
+        app.current_items = app.sorted(items, Some(&roots));
 
         if !app.current_items.is_empty() {
             app.current_state.select(Some(0));
@@ -298,26 +319,23 @@ impl App {
     fn update_panes(&mut self) {
         // Use the selected item in current_items as the focus
         let selected_idx = self.current_state.selected().unwrap_or(0);
-        if let Some(path) = self.current_items.get(selected_idx) {
+        if let Some(path) = self.current_items.get(selected_idx).cloned() {
             self.current_path = Some(path.clone());
 
-            // Update referrers (left pane)
-            self.previous_items = self
+            let parents = self
                 .stats
-                .get(path)
+                .get(&path)
                 .map(|s| s.immediate_parents.clone())
                 .unwrap_or_default();
-            crate::path_stats::sort_paths(&mut self.previous_items, &self.stats, self.sort_order);
+            self.previous_items = self.sorted(parents, None);
 
-            // Update dependencies (right pane)
-            let mut refs = self
+            let refs = self
                 .graph
-                .get_references(path)
+                .get_references(&path)
                 .into_iter()
                 .map(|p| p.path.clone())
                 .collect::<Vec<_>>();
-            crate::path_stats::sort_paths(&mut refs, &self.stats, self.sort_order);
-            self.next_items = refs;
+            self.next_items = self.sorted(refs, Some(std::slice::from_ref(&path)));
 
             // Reset selections in side panes but keep current pane focus
             self.previous_state = ListState::default();
@@ -337,9 +355,14 @@ impl App {
     }
 
     fn resort_current_pane(&mut self) {
-        crate::path_stats::sort_paths(&mut self.current_items, &self.stats, self.sort_order);
-        crate::path_stats::sort_paths(&mut self.previous_items, &self.stats, self.sort_order);
-        crate::path_stats::sort_paths(&mut self.next_items, &self.stats, self.sort_order);
+        let parent = self.get_parent_context();
+        let next_ctx = self.current_path.clone().map(|p| vec![p]);
+        let cur = std::mem::take(&mut self.current_items);
+        let prev = std::mem::take(&mut self.previous_items);
+        let next = std::mem::take(&mut self.next_items);
+        self.current_items = self.sorted(cur, Some(&parent));
+        self.previous_items = self.sorted(prev, None);
+        self.next_items = self.sorted(next, next_ctx.as_deref());
     }
 
     fn perform_search(&mut self) {
@@ -357,8 +380,8 @@ impl App {
             .collect();
 
         if !matching_paths.is_empty() {
-            self.current_items = matching_paths;
-            crate::path_stats::sort_paths(&mut self.current_items, &self.stats, self.sort_order);
+            let roots = self.graph.roots.clone();
+            self.current_items = self.sorted(matching_paths, Some(&roots));
             self.current_state.select(Some(0));
             self.active_pane = Pane::Current;
             self.update_panes();
@@ -412,9 +435,8 @@ impl App {
         // Clear navigation history
         self.navigation_history.clear();
 
-        // Start from roots
-        self.current_items = self.graph.roots.clone();
-        crate::path_stats::sort_paths(&mut self.current_items, &self.stats, self.sort_order);
+        let roots = self.graph.roots.clone();
+        self.current_items = self.sorted(roots.clone(), Some(&roots));
 
         // Navigate through the path
         for (i, target) in path.iter().enumerate() {


### PR DESCRIPTION

The previous message unconditionally suggested --derivation, which is
wrong advice when the path was simply garbage-collected (the common case
for old profile generations passed to --diff). Mention both
possibilities so the hint stays useful without being misleading.
