### PR TITLE
docs: add vhs screencast and embed it in the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 /result
+/docs/demo.webp

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Interactively browse dependency graphs of Nix derivations. A Rust port of
 [nix-tree].
 
+![demo](https://github.com/Mic92/nix-tree-rs/releases/download/assets/demo.webp)
+
 ## Why a port?
 
 On large closures the original spends most of its startup computing closure

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,0 +1,58 @@
+# Render with: ./docs/render-demo.sh
+
+Output docs/demo.webp
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1200
+Set Height 720
+Set Theme "Catppuccin Mocha"
+Set TypingSpeed 40ms
+Set PlaybackSpeed 1.0
+
+Type "nix-tree ~/.nix-profile"
+Sleep 500ms
+Enter
+# Skip closure load time.
+Hide
+Sleep 5s
+Show
+Sleep 1s
+
+# user-environment -> home-manager-path -> packages
+Right
+Sleep 700ms
+Down
+Sleep 500ms
+Right
+Sleep 1s
+
+Down@120ms 10
+Sleep 1s
+
+# why-depends
+Type "w"
+Sleep 2.5s
+Escape
+Sleep 500ms
+
+# search
+Type "/"
+Sleep 400ms
+Type "openssl"
+Sleep 1.5s
+Enter
+Sleep 1.5s
+
+# sort toggle
+Type "s"
+Sleep 1.5s
+
+# help
+Type "?"
+Sleep 3s
+Escape
+Sleep 500ms
+
+Type "q"
+Sleep 500ms

--- a/docs/render-demo.sh
+++ b/docs/render-demo.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env nix
+#!nix shell nixpkgs#vhs nixpkgs#ttyd nixpkgs#ffmpeg nixpkgs#bashInteractive --command bash
+# shellcheck shell=bash
+# bashInteractive: vhs spawns `bash` from PATH; the stdenv bash lacks readline,
+# which makes PS1's \[ \] markers leak into the recording.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Put a fresh nix-tree on PATH so the tape has no `nix run` delay.
+nix build .#
+export PATH="$PWD/result/bin:$PATH"
+
+exec vhs docs/demo.tape


### PR DESCRIPTION

Show the TUI in motion instead of describing it. The render script pins
vhs/ttyd/ffmpeg via a nix shebang and adds bashInteractive so readline
PS1 markers do not leak. The webp lives on the assets release tag, not
in the repo.


